### PR TITLE
Add TalOS image factory definition

### DIFF
--- a/image.yml
+++ b/image.yml
@@ -1,0 +1,9 @@
+# 077514df2c1b6436460bc60faabc976687b16193b8a1290fda4366c69024fec2
+# https://factory.talos.dev/image/077514df2c1b6436460bc60faabc976687b16193b8a1290fda4366c69024fec2/v1.12.6/metal-amd64.qcow2
+customization:
+  systemExtensions:
+    officialExtensions:
+      - siderolabs/iscsi-tools
+      - siderolabs/qemu-guest-agent
+      - siderolabs/tailscale
+      - siderolabs/util-linux-tools


### PR DESCRIPTION
## Summary
- add public TalOS Image Factory definition in image.yml
- include required official system extensions for this environment
- keep the repository limited to reproducible, non-sensitive configuration

## Testing
- not run (configuration file only)