### PR TITLE
Add Nix Talos environment and CI

### DIFF
--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -1,0 +1,42 @@
+name: Nix CI
+
+on:
+  pull_request:
+    paths:
+      - "flake.nix"
+      - "**/*.nix"
+      - "flake.lock"
+      - ".github/workflows/nix-ci.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "flake.nix"
+      - "**/*.nix"
+      - "flake.lock"
+      - ".github/workflows/nix-ci.yml"
+
+jobs:
+  devshell:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v15
+
+      - name: Configure Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@v8
+
+      - name: Evaluate flake
+        run: nix flake show
+
+      - name: Build dev shell
+        run: nix develop .#default --command bash -lc 'command -v talosctl talhelper kubectl jq yq sops age'
+
+      - name: Smoke test Talos tooling
+        run: |
+          nix develop .#default --command talosctl version --client
+          nix develop .#default --command talhelper --help >/dev/null

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.direnv/
+/result

--- a/README.md
+++ b/README.md
@@ -20,6 +20,48 @@ TalOS ベースのインフラを管理するためのリポジトリです。
 
 現時点では [`image.yml`](/home/azuki/work/mistship/image.yml) に TalOS イメージ拡張の定義を置いています。これは公開可能な情報のみで構成します。
 
+## Nix 開発環境
+
+TalOS を操作する CLI は [`flake.nix`](/home/azuki/work/mistship/flake.nix) の `devShell` でまとめて提供します。
+
+```bash
+nix develop
+```
+
+このシェルには次のコマンドを入れます。
+
+- `talosctl`
+- `talhelper`
+- `kubectl`
+- `jq`
+- `yq`
+- `sops`
+- `age`
+
+シェル起動時に次の環境変数を既定で設定します。
+
+- `MISTSHIP_SECRETS_DIR=${MISTSHIP_SECRETS_DIR:-$HOME/secure/mistship}`
+- `TALOSCONFIG=${TALOSCONFIG:-$MISTSHIP_SECRETS_DIR/talosconfig}`
+- `KUBECONFIG=${KUBECONFIG:-$MISTSHIP_SECRETS_DIR/kubeconfig}`
+
+想定しているローカル配置例:
+
+```text
+~/secure/mistship/
+├── talosconfig
+├── kubeconfig
+└── nodes.yaml
+```
+
+動作確認例:
+
+```bash
+nix develop --command talosctl version --client
+nix develop --command talhelper --help
+```
+
+`flake.lock` はコミットして、チーム内で同じ `nixpkgs` リビジョンを使う前提にします。更新したい時だけ `nix flake update` を実行します。
+
 ## Git に含めないもの
 
 以下は公開リポジトリに含めません。

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1773821835,
+        "narHash": "sha256-TJ3lSQtW0E2JrznGVm8hOQGVpXjJyXY2guAxku2O9A4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b40629efe5d6ec48dd1efba650c797ddbd39ace0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,54 @@
+{
+  description = "Development shell for operating Talos clusters";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      devShells = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              age
+              jq
+              kubectl
+              sops
+              talhelper
+              talosctl
+              yq-go
+            ];
+
+            shellHook = ''
+              export MISTSHIP_SECRETS_DIR="''${MISTSHIP_SECRETS_DIR:-$HOME/secure/mistship}"
+              export TALOSCONFIG="''${TALOSCONFIG:-$MISTSHIP_SECRETS_DIR/talosconfig}"
+              export KUBECONFIG="''${KUBECONFIG:-$MISTSHIP_SECRETS_DIR/kubeconfig}"
+
+              echo "mistship Talos shell"
+              echo "  MISTSHIP_SECRETS_DIR=$MISTSHIP_SECRETS_DIR"
+              echo "  TALOSCONFIG=$TALOSCONFIG"
+              echo "  KUBECONFIG=$KUBECONFIG"
+            '';
+          };
+        });
+
+      formatter = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        pkgs.nixpkgs-fmt);
+    };
+}


### PR DESCRIPTION
## Summary
- add a Nix flake dev shell for Talos operations
- pin nixpkgs with flake.lock and document how to use the environment
- add GitHub Actions CI to evaluate the flake and smoke test the Talos tooling

## Testing
- nix flake show path:.
- nix develop path:. --command talosctl version --client
- nix develop path:. --command talhelper --help