### PR TITLE
FlakeHub認証用のOIDC権限をworkflowに追加

### DIFF
--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -19,6 +19,9 @@ on:
 jobs:
   devshell:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/talos-update.yml
+++ b/.github/workflows/talos-update.yml
@@ -22,6 +22,7 @@ concurrency:
 permissions:
   contents: read
   deployments: write
+  id-token: write
 
 jobs:
   update-control-plane:


### PR DESCRIPTION
## 概要
- `magic-nix-cache-action` が FlakeHub 認証に使う OIDC 権限を workflow に追加しました
- `nix-ci.yml` と `talos-update.yml` の両方を修正しました

## 背景
CI で次のエラーが出ていました。

```text
Error: Unable to authenticate to FlakeHub.
```

`DeterminateSystems/magic-nix-cache-action` は GitHub Actions の OIDC トークンを使うため、`id-token: write` が必要です。現状の workflow にはその権限が無く、FlakeHub 認証に失敗していました。

## 変更内容
- `.github/workflows/nix-ci.yml` に `permissions` を追加
  - `contents: read`
  - `id-token: write`
- `.github/workflows/talos-update.yml` の `permissions` に `id-token: write` を追加

## 動作確認
- `git diff --check`
- `env XDG_CACHE_HOME=/tmp/xdg-cache nix develop .#default --command yq eval '.' .github/workflows/nix-ci.yml >/dev/null`
- `env XDG_CACHE_HOME=/tmp/xdg-cache nix develop .#default --command yq eval '.' .github/workflows/talos-update.yml >/dev/null`