### PR TITLE
Omit empty worker config patch in cluster-access

### DIFF
--- a/.github/actions/cluster-access/action.yml
+++ b/.github/actions/cluster-access/action.yml
@@ -108,13 +108,19 @@ runs:
         set -euo pipefail
         nix develop .#default --command bash -lc '
           set -euo pipefail
+          worker_patch_args=()
+          worker_patch_contents="$(grep -vE "^[[:space:]]*(#|$)" patches/worker.yaml | tr -d "[:space:]" || true)"
+          if [[ -n "$worker_patch_contents" && "$worker_patch_contents" != "{}" ]]; then
+            worker_patch_args+=(--config-patch-worker "@patches/worker.yaml")
+          fi
+
           talosctl gen config "$CLUSTER_NAME" "https://$CONTROL_PLANE_IP:6443" \
             --with-secrets "$CLUSTER_SECRETS" \
             --install-disk "$INSTALL_DISK" \
             --install-image "$INSTALL_IMAGE" \
             --config-patch "@patches/common.yaml" \
             --config-patch-control-plane "@patches/controlplane.yaml" \
-            --config-patch-worker "@patches/worker.yaml" \
+            "${worker_patch_args[@]}" \
             --output "$GENERATED_CONFIG_DIR"
 
           cp "$GENERATED_CONFIG_DIR/controlplane.yaml" "$CONTROL_PLANE_CONFIG"


### PR DESCRIPTION
## Summary
- omit `--config-patch-worker` when `patches/worker.yaml` is effectively empty
- keep passing the worker patch only when it contains an actual patch

## Verification
- YAML validation with `yq`
- `bash -n` on the embedded script
- local behavior check for blank/comment-only/`{}`/non-empty worker patch files