### PR TITLE
Fix Calico API endpoint configuration

### DIFF
--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -263,7 +263,7 @@ Calico の apply 順は次の順に固定します。
 1. `APIServer`
 1. `FelixConfiguration`
 
-`kubernetes-services-endpoint` は KubePrism 前提で `localhost:7445` を使います。
+`kubernetes-services-endpoint` は [`scripts/apply-calico.sh`](/home/azuki/work/mistship/scripts/apply-calico.sh) が現在の `kubeconfig` から API endpoint を解決して生成します。single-node control plane では通常 `https://<CONTROL_PLANE_IP>:6443` になります。
 `Installation` では `linuxDataplane: BPF` を使い、`kubeProxyManagement: Enabled` にして Calico から `kube-proxy` を無効化します。
 
 Calico の導入は次で実行します。
@@ -338,7 +338,7 @@ kubectl --kubeconfig "$KUBECONFIG" get tigerastatus
 kubectl --kubeconfig "$KUBECONFIG" get crd | rg 'operator.tigera.io|projectcalico.org'
 ```
 
-`kubeconfig` で API に到達できない場合は、`localhost:7445` と TalOS の `kubePrism` 設定、または `cluster.network.cni.name: none` / `cluster.proxy.disabled: true` の抜けを疑います。
+`kubeconfig` で API に到達できない場合は、`kubeconfig` に入っている API endpoint と TalOS の control plane endpoint、または `cluster.network.cni.name: none` / `cluster.proxy.disabled: true` の抜けを疑います。
 
 ## 実施順の要点
 

--- a/docs/networking-migration.md
+++ b/docs/networking-migration.md
@@ -86,7 +86,7 @@ talosctl bootstrap \
 Kubernetes API が上がったら、`kubeconfig` を取得して Calico を staged apply します。
 
 順序は [`scripts/apply-calico.sh`](/home/azuki/work/mistship/scripts/apply-calico.sh) に固定しています。
-`kubernetes-services-endpoint` は `localhost:7445` を使い、Calico の eBPF bootstrap と TalOS の KubePrism をつなぎます。
+`kubernetes-services-endpoint` は [`scripts/apply-calico.sh`](/home/azuki/work/mistship/scripts/apply-calico.sh) が `kubeconfig` から解決した API endpoint で生成します。single-node control plane では通常 `https://<CONTROL_PLANE_IP>:6443` を使います。
 
 ```bash
 KUBECONFIG="$KUBECONFIG" nix develop .#default --command ./scripts/apply-calico.sh
@@ -132,7 +132,7 @@ kubectl --kubeconfig "$KUBECONFIG" -n calico-system get pods -o wide
 
 Calico が起動しない場合は、まず次を確認します。
 
-- `localhost:7445` が KubePrism と一致しているか
+- `kubeconfig` の API endpoint が実際の control plane endpoint と一致しているか
 - `cluster.network.cni.name: none` が入っているか
 - `cluster.proxy.disabled: true` が入っているか
 - 旧 `Flannel` / `kube-proxy` の残骸が node に残っていないか

--- a/manifests/infra/README.md
+++ b/manifests/infra/README.md
@@ -15,4 +15,4 @@
 
 このディレクトリに `*.yaml`、`*.yml`、`*.json` がまだ無い場合、CI の apply step は自動的にスキップされます。
 
-Calico を置く場合は、`manifests/infra/calico/` 配下を先に ordered apply し、その後で残りの `manifests/infra/` を適用します。
+Calico を置く場合は、`manifests/infra/calico/` 配下を [`scripts/apply-calico.sh`](/home/azuki/work/mistship/scripts/apply-calico.sh) で先に ordered apply し、その後で残りの `manifests/infra/` を適用します。`kubernetes-services-endpoint` ConfigMap は current `kubeconfig` から動的に生成するため、`manifests/infra/calico/` の raw apply は前提にしません。

--- a/manifests/infra/calico/10-kubernetes-services-endpoint.yaml
+++ b/manifests/infra/calico/10-kubernetes-services-endpoint.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kubernetes-services-endpoint
-  namespace: tigera-operator
-data:
-  KUBERNETES_SERVICE_HOST: localhost
-  KUBERNETES_SERVICE_PORT: "7445"

--- a/scripts/apply-calico.sh
+++ b/scripts/apply-calico.sh
@@ -4,6 +4,103 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 calico_dir="$repo_root/manifests/infra/calico"
+kubernetes_service_host=""
+kubernetes_service_port=""
+
+dump_tigera_operator_diagnostics() {
+  kubectl get pods -n tigera-operator -o wide || true
+  kubectl describe deployment/tigera-operator -n tigera-operator || true
+  kubectl logs deployment/tigera-operator -n tigera-operator --tail=200 || true
+}
+
+dump_namespace_diagnostics() {
+  local namespace="$1"
+  local pod
+  local logs_found=0
+
+  kubectl get all -n "$namespace" -o wide || true
+  kubectl get pods -n "$namespace" -o wide || true
+  kubectl get events -n "$namespace" --sort-by=.metadata.creationTimestamp || true
+  kubectl describe pods -n "$namespace" || true
+
+  while IFS= read -r pod; do
+    logs_found=1
+    kubectl logs -n "$namespace" "$pod" --all-containers=true --tail=200 --prefix=true || true
+  done < <(kubectl get pods -n "$namespace" -o name 2>/dev/null)
+
+  if (( logs_found == 0 )); then
+    echo "No pods found in namespace $namespace for log collection." >&2
+  fi
+}
+
+rollout_status_or_dump() {
+  local kind="$1"
+  local name="$2"
+  local namespace="$3"
+  local timeout="$4"
+
+  if ! kubectl rollout status "$kind/$name" -n "$namespace" --timeout="$timeout"; then
+    echo "Rollout failed for $kind/$name in namespace $namespace." >&2
+    kubectl describe "$kind/$name" -n "$namespace" || true
+    dump_namespace_diagnostics "$namespace"
+    return 1
+  fi
+}
+
+resolve_kubernetes_api_endpoint() {
+  local server authority
+
+  if [[ -n "${CALICO_KUBERNETES_SERVICE_HOST:-}" ]]; then
+    kubernetes_service_host="$CALICO_KUBERNETES_SERVICE_HOST"
+    kubernetes_service_port="${CALICO_KUBERNETES_SERVICE_PORT:-6443}"
+    return 0
+  fi
+
+  server="$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')"
+  if [[ -z "$server" ]]; then
+    echo "Unable to determine Kubernetes API server from kubeconfig." >&2
+    return 1
+  fi
+
+  authority="${server#*://}"
+  authority="${authority%%/*}"
+
+  if [[ "$authority" == *:* ]]; then
+    kubernetes_service_host="${authority%%:*}"
+    kubernetes_service_port="${authority##*:}"
+  else
+    kubernetes_service_host="$authority"
+    kubernetes_service_port="443"
+  fi
+}
+
+apply_kubernetes_services_endpoint_configmap() {
+  resolve_kubernetes_api_endpoint
+
+  kubectl create configmap kubernetes-services-endpoint \
+    -n tigera-operator \
+    --from-literal=KUBERNETES_SERVICE_HOST="$kubernetes_service_host" \
+    --from-literal=KUBERNETES_SERVICE_PORT="$kubernetes_service_port" \
+    --dry-run=client \
+    -o yaml | kubectl apply -f -
+}
+
+wait_for_crd() {
+  local crd_name="$1"
+  local timeout_seconds="${2:-120}"
+  local deadline=$((SECONDS + timeout_seconds))
+
+  until kubectl get crd "$crd_name" >/dev/null 2>&1; do
+    if (( SECONDS >= deadline )); then
+      echo "Timed out waiting for CRD $crd_name to be created." >&2
+      dump_tigera_operator_diagnostics
+      return 1
+    fi
+    sleep 2
+  done
+
+  kubectl wait --for=condition=Established "crd/$crd_name" --timeout="${timeout_seconds}s"
+}
 
 if [[ ! -d "$calico_dir" ]]; then
   echo "No Calico manifests found under $calico_dir; skipping Calico apply."
@@ -11,22 +108,22 @@ if [[ ! -d "$calico_dir" ]]; then
 fi
 
 kubectl apply -f "$calico_dir/00-namespace.yaml"
-kubectl apply -f "$calico_dir/10-kubernetes-services-endpoint.yaml"
+apply_kubernetes_services_endpoint_configmap
 kubectl apply -f "$calico_dir/20-tigera-operator.yaml"
 
 kubectl rollout status deployment/tigera-operator -n tigera-operator --timeout=5m
 
-kubectl wait --for=condition=Established crd/installations.operator.tigera.io --timeout=2m
-kubectl wait --for=condition=Established crd/apiservers.operator.tigera.io --timeout=2m
-kubectl wait --for=condition=Established crd/felixconfigurations.crd.projectcalico.org --timeout=2m
-kubectl wait --for=condition=Established crd/tigerastatuses.operator.tigera.io --timeout=2m
+wait_for_crd installations.operator.tigera.io
+wait_for_crd apiservers.operator.tigera.io
+wait_for_crd felixconfigurations.crd.projectcalico.org
+wait_for_crd tigerastatuses.operator.tigera.io
 
 kubectl apply -f "$calico_dir/30-installation.yaml"
 kubectl apply -f "$calico_dir/31-apiserver.yaml"
 kubectl apply -f "$calico_dir/32-felixconfiguration.yaml"
 
-kubectl rollout status deployment/calico-kube-controllers -n calico-system --timeout=10m
-kubectl rollout status daemonset/calico-node -n calico-system --timeout=10m
-kubectl rollout status deployment/calico-apiserver -n calico-apiserver --timeout=10m
+rollout_status_or_dump deployment calico-kube-controllers calico-system 10m
+rollout_status_or_dump daemonset calico-node calico-system 10m
+rollout_status_or_dump deployment calico-apiserver calico-apiserver 10m
 
 kubectl get tigerastatus

--- a/scripts/validate-manifests.sh
+++ b/scripts/validate-manifests.sh
@@ -25,16 +25,10 @@ fi
 
 built_in_files=(
   "$calico_dir/00-namespace.yaml" \
-  "$calico_dir/10-kubernetes-services-endpoint.yaml" \
   "$calico_dir/20-tigera-operator.yaml"
 )
 
 kubeconform -strict -summary "${built_in_files[@]}"
-
-yq eval -e '.apiVersion == "v1"' "$calico_dir/10-kubernetes-services-endpoint.yaml" >/dev/null
-yq eval -e '.kind == "ConfigMap"' "$calico_dir/10-kubernetes-services-endpoint.yaml" >/dev/null
-yq eval -e '.data.KUBERNETES_SERVICE_HOST == "localhost"' "$calico_dir/10-kubernetes-services-endpoint.yaml" >/dev/null
-yq eval -e '.data.KUBERNETES_SERVICE_PORT == "7445"' "$calico_dir/10-kubernetes-services-endpoint.yaml" >/dev/null
 
 yq eval -e '.apiVersion == "operator.tigera.io/v1"' "$calico_dir/30-installation.yaml" >/dev/null
 yq eval -e '.kind == "Installation"' "$calico_dir/30-installation.yaml" >/dev/null


### PR DESCRIPTION
## Summary
- generate the Calico kubernetes-services-endpoint ConfigMap from the current kubeconfig API endpoint instead of a static localhost:7445 manifest
- make apply-calico wait for CRD creation and dump rollout diagnostics on failure
- update validation and docs to match the dynamic ConfigMap flow

## Testing
- bash -n scripts/apply-calico.sh
- bash -n scripts/validate-manifests.sh
- env XDG_CACHE_HOME=/tmp/xdg-cache nix develop .#default --command bash ./scripts/validate-manifests.sh