### PR TITLE
Fix calico-apiserver rollout namespace

### DIFF
--- a/scripts/apply-calico.sh
+++ b/scripts/apply-calico.sh
@@ -124,6 +124,6 @@ kubectl apply -f "$calico_dir/32-felixconfiguration.yaml"
 
 rollout_status_or_dump deployment calico-kube-controllers calico-system 10m
 rollout_status_or_dump daemonset calico-node calico-system 10m
-rollout_status_or_dump deployment calico-apiserver calico-apiserver 10m
+rollout_status_or_dump deployment calico-apiserver calico-system 10m
 
 kubectl get tigerastatus


### PR DESCRIPTION
## Summary
- fix the Calico apply script to wait for `calico-apiserver` in `calico-system`
- align rollout checks with the namespace actually used by the Tigera operator

## Why
The merged `Fix Calico API endpoint configuration` PR corrected the API endpoint issue, but the subsequent `Talos Update` run `23353213545` still failed on 2026-03-21 because the script was checking a non-existent `calico-apiserver` namespace.

## Testing
- bash -n scripts/apply-calico.sh