### PR TITLE
docs: rename repo references to mistship-bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# mistship
+# mistship-bootstrap
 
-`mistship` は、TalOS クラスタを手元で bootstrap し、Argo CD を入れて GitOps に渡すまでを管理する public repo です。
+`mistship-bootstrap` は、TalOS クラスタを手元で bootstrap し、Argo CD を入れて GitOps に渡すまでを管理する public repo です。
 
 この repo に置くのは、公開可能な定義、SOPS で暗号化した cluster input、ローカル bootstrap 手順です。継続運用用の manifest や CI/CD からの cluster apply は扱いません。
+
+`mistship-bootstrap` という名前どおり、この repo の責務は bootstrap までです。Argo CD 導入後の継続運用は別の deploy repo に渡します。
 
 ## 何を置くか
 
@@ -51,6 +53,8 @@ bash ./scripts/prepare-cluster-access.sh
 ├── image.yml
 └── flake.nix
 ```
+
+現時点では、暗号化済み cluster input の格納 path は `secrets/mistship/` のままです。repo 名の rename と path / env var の rename は分けて扱います。
 
 ## 秘密情報
 

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -1,6 +1,6 @@
 # TalOS Bootstrap
 
-TalOS の control plane を立ち上げるまでの最短手順です。前提は、node が maintenance mode で起動しており、SOPS 暗号化済み input が `secrets/mistship/` にあることです。
+`mistship-bootstrap` で TalOS の control plane を立ち上げるまでの最短手順です。前提は、node が maintenance mode で起動しており、SOPS 暗号化済み input が現行 path の `secrets/mistship/` にあることです。
 
 ## 1. 入力を復号する
 

--- a/docs/networking-stack.md
+++ b/docs/networking-stack.md
@@ -1,6 +1,6 @@
 # TalOS クラスタのネットワーク構成方針
 
-この文書は、`mistship` で採用する Kubernetes ネットワーク構成を記録するための設計メモです。
+この文書は、`mistship-bootstrap` で bootstrap 対象にしている Kubernetes ネットワーク構成を記録するための設計メモです。
 
 対象は TalOS v1.12 系を前提にした single-cluster 構成です。
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,6 +1,8 @@
 # Secret Management with SOPS
 
-この repo に置く secret 関連ファイルは、SOPS で暗号化した input だけです。平文 secret は `.secret/` にだけ置きます。
+`mistship-bootstrap` に置く secret 関連ファイルは、SOPS で暗号化した input だけです。平文 secret は `.secret/` にだけ置きます。
+
+repo 名は `mistship-bootstrap` ですが、現時点の暗号化済み input の格納 path は `secrets/mistship/` のままです。
 
 ## Git に置くもの
 

--- a/manifests/bootstrap/ebpf-demo/README.md
+++ b/manifests/bootstrap/ebpf-demo/README.md
@@ -1,6 +1,6 @@
 # Calico eBPF Service デモ
 
-この手順は、`mistship` の `Calico eBPF` dataplane を使って `Service` 転送が動いていることを確認するためのものです。
+この手順は、`mistship-bootstrap` が bootstrap 対象にしているクラスタで `Calico eBPF` dataplane を使って `Service` 転送が動いていることを確認するためのものです。
 
 目的:
 


### PR DESCRIPTION
## Summary
- rename the repository references in the main docs to `mistship-bootstrap`
- make the bootstrap-only scope explicit in the top-level README
- clarify that `secrets/mistship/` remains the current path until a follow-up rename

## Testing
- bash ./scripts/check-doc-links.sh
