### PR TITLE
fix(nix): prefer repo kubeconfig in dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -65,8 +65,27 @@
             shellHook = ''
               repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
               export MISTSHIP_SECRETS_DIR="''${MISTSHIP_SECRETS_DIR:-$repo_root/.secret}"
-              export TALOSCONFIG="''${TALOSCONFIG:-$MISTSHIP_SECRETS_DIR/talosconfig}"
-              export KUBECONFIG="''${KUBECONFIG:-$MISTSHIP_SECRETS_DIR/kubeconfig}"
+
+              if [[ -z "''${TALOSCONFIG:-}" ]]; then
+                if [[ -f "$repo_root/talosconfig" ]]; then
+                  export TALOSCONFIG="$repo_root/talosconfig"
+                else
+                  export TALOSCONFIG="$MISTSHIP_SECRETS_DIR/talosconfig"
+                fi
+              fi
+
+              if [[ -z "''${KUBECONFIG:-}" ]]; then
+                if [[ -f "$repo_root/kubeconfig" ]]; then
+                  export KUBECONFIG="$repo_root/kubeconfig"
+                else
+                  repo_kubeconfig="$(find "$repo_root" -path "$MISTSHIP_SECRETS_DIR" -prune -o -type f \( -name kubeconfig -o -name '*.kubeconfig' \) -print -quit 2>/dev/null)"
+                  if [[ -n "$repo_kubeconfig" ]]; then
+                    export KUBECONFIG="$repo_kubeconfig"
+                  else
+                    export KUBECONFIG="$MISTSHIP_SECRETS_DIR/kubeconfig"
+                  fi
+                fi
+              fi
 
               echo "mistship Talos shell"
               echo "  REPO_ROOT=$repo_root"


### PR DESCRIPTION
## Summary
- prefer a repo-local kubeconfig when entering nix develop
- prefer a repo-local talosconfig before falling back to .secret
- keep .secret/kubeconfig as the final fallback

## Verification
- ran nix develop and confirmed KUBECONFIG resolves inside the repo