### PR TITLE
fix(bootstrap): use server-side apply for argocd

### DIFF
--- a/docs/gitops-bootstrap.md
+++ b/docs/gitops-bootstrap.md
@@ -16,7 +16,10 @@ bash ./scripts/apply-bootstrap-manifests.sh
 このスクリプトは次を行います。
 
 1. `scripts/apply-calico.sh` で Calico を staged apply
-2. `manifests/bootstrap/argocd/` を `kubectl apply -k` で適用
+2. `manifests/bootstrap/argocd/` を `kubectl apply --server-side -k` で適用
+
+Argo CD の upstream manifest にはサイズの大きい CRD が含まれるため、client-side apply だと
+`metadata.annotations: Too long` で失敗し得ます。この repo では bootstrap 時に server-side apply を使います。
 
 ## 確認
 

--- a/manifests/bootstrap/README.md
+++ b/manifests/bootstrap/README.md
@@ -17,4 +17,6 @@
 bash ./scripts/apply-bootstrap-manifests.sh
 ```
 
-このスクリプトは `calico/` を先に適用し、その後 `argocd/` を適用します。`ebpf-demo/` は既定では apply しません。
+このスクリプトは `calico/` を先に適用し、その後 `argocd/` を server-side apply で適用します。
+Argo CD の CRD は大きいため、client-side apply だと annotation size 制限に当たる場合があります。
+`ebpf-demo/` は既定では apply しません。

--- a/scripts/apply-bootstrap-manifests.sh
+++ b/scripts/apply-bootstrap-manifests.sh
@@ -17,7 +17,9 @@ echo "::group::Apply Calico"
 echo "::endgroup::"
 
 echo "::group::Apply Argo CD bootstrap manifest"
-kubectl --kubeconfig "$KUBECONFIG" apply -k manifests/bootstrap/argocd
+# Argo CD bundles large CRDs, so use server-side apply to avoid
+# exceeding the last-applied-configuration annotation limit.
+kubectl --kubeconfig "$KUBECONFIG" apply --server-side -k manifests/bootstrap/argocd
 echo "::endgroup::"
 
 if [[ -d manifests/bootstrap/ebpf-demo ]]; then

--- a/scripts/validate-manifests.sh
+++ b/scripts/validate-manifests.sh
@@ -64,6 +64,8 @@ if [[ -d "$argocd_dir" ]]; then
   yq eval -e '.namespace == "argocd"' "$argocd_dir/kustomization.yaml" >/dev/null
   yq eval -e '.resources[0] == "00-namespace.yaml"' "$argocd_dir/kustomization.yaml" >/dev/null
   yq eval -e '.resources[1] == "https://raw.githubusercontent.com/argoproj/argo-cd/v3.3.4/manifests/install.yaml"' "$argocd_dir/kustomization.yaml" >/dev/null
+  grep -F 'kubectl --kubeconfig "$KUBECONFIG" apply --server-side -k manifests/bootstrap/argocd' \
+    scripts/apply-bootstrap-manifests.sh >/dev/null
 fi
 
 echo "Manifest validation passed."


### PR DESCRIPTION
## Summary
- switch Argo CD bootstrap to server-side apply to avoid CRD annotation size failures
- document why bootstrap uses server-side apply for the upstream Argo CD manifest
- add a validation check that keeps the bootstrap script on server-side apply

## Verification
- bash -n scripts/apply-bootstrap-manifests.sh scripts/validate-manifests.sh
- bash scripts/validate-manifests.sh