### PR TITLE
docs: note private ownership of TalOS ingress firewall patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - `talosconfig`、`kubeconfig`
 - 生成済み machine config
 - Argo CD 導入後の継続運用 manifest
+- 実環境固有の TalOS ingress firewall patch
 - deploy repo を指す `Application`
 
 ## 最短フロー

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -74,6 +74,8 @@ GENERATE_KUBECONFIG=true bash ./scripts/prepare-cluster-access.sh
 kubectl --kubeconfig "$KUBECONFIG" get nodes -o wide
 ```
 
+TalOS ingress firewall patch はこの repo では管理せず、local で復号した `.secret/talosconfig` を使って private repo 側から別途適用します。
+
 ここまで終わったら次へ進みます。
 
 - [docs/gitops-bootstrap.md](gitops-bootstrap.md)

--- a/docs/networking-stack.md
+++ b/docs/networking-stack.md
@@ -98,7 +98,7 @@ TalOS 側では、`cluster.network.cni.name` を `none` にする前提で構成
 ## 運用メモ
 
 - `KubeSpan` 用に UDP `51820` を通す
-- TalOS ingress firewall を `block` で使う場合は、`KubeSpan` と Kubernetes API に必要な通信を明示的に許可する
+- TalOS ingress firewall patch 自体はこの repo では管理せず、private repo 側で別管理する
 - `Calico eBPF` は `kube-proxy` なし前提なので、bootstrap 手順と manifest 適用順を固定する
 
 ## リスク


### PR DESCRIPTION
## Summary
- note that environment-specific TalOS ingress firewall patches are managed outside this public repo
- clarify in bootstrap docs that the local decrypted .secret/talosconfig can be used from the private repo side
- keep the networking notes aligned with that ownership boundary

## Testing
- bash ./scripts/ci-talos-preflight.sh