### PR TITLE
[codex] Add Auth0 OIDC support for control plane

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ GitHub Actions は検証専用で、cluster への deploy や apply はしませ
 
 - [docs/bootstrap.md](docs/bootstrap.md)
 - [docs/gitops-bootstrap.md](docs/gitops-bootstrap.md)
+- [docs/auth0-oidc.md](docs/auth0-oidc.md)
 - [docs/secrets.md](docs/secrets.md)
 - [docs/networking-stack.md](docs/networking-stack.md)
 - [docs/networking-migration.md](docs/networking-migration.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,7 @@
 
 - 直下の `docs/` : 人間が読む前提の手順書・設計メモ
 - `docs/agents/` : AI エージェントやレビュー補助向けの指示書
+- `docs/auth0-oidc.md` : Kubernetes API Server の Auth0 OIDC 認証メモ
 - `docs/agents/commit-secret-reviewer.md` : commit 前の secret 混入検査ルール
 - `docs/agents/conventional-commit-writer.md` : commit message 生成ルール
 - `docs/agents/pull-request-creator.md` : 新規 PR 作成時のブランチ運用ルール

--- a/docs/auth0-oidc.md
+++ b/docs/auth0-oidc.md
@@ -1,0 +1,77 @@
+# Auth0 OIDC for Kubernetes API
+
+`mistship` の control plane は、Kubernetes API Server で Auth0 OIDC 認証を受ける前提です。
+この repo では control plane 用 TalOS config に OIDC 設定を埋め込み、`kubelogin` で取った ID Token を `kubectl` から使えるようにします。
+
+## Control plane に入れている設定
+
+`patches/controlplane.yaml` で次の OIDC 設定を `kube-apiserver` へ渡します。
+
+- issuer: `https://azk.jp.auth0.com/`
+- client ID: `x33YdbDxOrVfflDOdNmyLy6wCDgWCPGN`
+- username claim: `email`
+- groups claim: `https://mistship-cp.azuki.blue/groups`
+- groups prefix: `-`
+
+この構成は Auth0 の ID Token を受ける前提です。
+`urn:mistship:kubernetes` は API audience として `kubelogin` の認可要求に使いますが、API Server の `oidc-client-id` には使いません。
+
+## kubeconfig の例
+
+`kubectl` 側では `kubelogin` を使います。
+
+```yaml
+users:
+  - name: auth0-mistship
+    user:
+      exec:
+        apiVersion: client.authentication.k8s.io/v1beta1
+        command: kubelogin
+        args:
+          - get-token
+          - --oidc-issuer-url=https://azk.jp.auth0.com/
+          - --oidc-client-id=x33YdbDxOrVfflDOdNmyLy6wCDgWCPGN
+          - --oidc-extra-scope=openid
+          - --oidc-extra-scope=profile
+          - --oidc-extra-scope=email
+          - --oidc-extra-scope=offline_access
+          - --oidc-auth-request-extra-params=audience=urn:mistship:kubernetes
+```
+
+既存の cluster context にこの user を紐付けるか、OIDC 用の別 user/context を追加して使います。
+
+## 最初の確認方法
+
+最初は group bind ではなく user 直 bind で確認します。
+username claim は `email` なので、最初の疎通確認はそのメールアドレスに対する `ClusterRoleBinding` を使います。
+
+例:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: auth0-azuki774-cluster-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: azuki774s@gmail.com
+```
+
+この binding は恒久運用の最終形ではなく、OIDC 認証と username claim の確認用です。
+
+## Groups claim の注意
+
+group ベースへ移るときは、Auth0 側で `https://mistship-cp.azuki.blue/groups` claim に値が入っていることを先に確認します。
+
+参照元メモの前提では、Auth0 Action は次の優先順で group claim を作ります。
+
+1. `user.app_metadata.kubernetes_groups`
+2. `event.authorization.roles`
+
+ただし `user.app_metadata.kubernetes_groups` が空配列でも存在すると、roles へフォールバックしません。
+group ベース RBAC に移る前に、対象 user の claim 内容を必ず確認してください。

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -63,6 +63,9 @@ bash ./scripts/ops/prepare-cluster-access.sh
 - `.secret/nodes/controlplane.yaml`
 - `.secret/nodes/worker.yaml`
 
+生成される `controlplane.yaml` には、この repo で管理している Auth0 OIDC 用の `kube-apiserver` 設定も含まれます。
+詳細は [docs/auth0-oidc.md](auth0-oidc.md) を参照してください。
+
 control plane や worker を Tailscale に参加させる場合は、`cluster-inputs.env` に role ごとの `TAILSCALE_CONTROLPLANE_*` / `TAILSCALE_WORKER_*` を入れたうえで同じ script を使います。
 詳細は [docs/tailscale.md](tailscale.md) を参照してください。
 

--- a/patches/controlplane.yaml
+++ b/patches/controlplane.yaml
@@ -1,6 +1,12 @@
 cluster:
   allowSchedulingOnControlPlanes: true
   apiServer:
+    extraArgs:
+      oidc-client-id: x33YdbDxOrVfflDOdNmyLy6wCDgWCPGN
+      oidc-groups-claim: https://mistship-cp.azuki.blue/groups
+      oidc-groups-prefix: "-"
+      oidc-issuer-url: https://azk.jp.auth0.com/
+      oidc-username-claim: email
     certSANs:
       - mistship-cp.azuki.blue
 machine:


### PR DESCRIPTION
## 概要
- controlplane の kube-apiserver に Auth0 OIDC 設定を追加
- Auth0 OIDC の利用手順と kubeconfig 例をドキュメント化
- bootstrap と README から新しい OIDC ドキュメントへ辿れるように更新

## 変更内容
- `patches/controlplane.yaml` に Auth0 issuer / client ID / claims 用の OIDC extraArgs を追加
- `docs/auth0-oidc.md` を追加して `kubelogin` 利用例と初回確認手順を整理
- `docs/bootstrap.md`、`docs/README.md`、`README.md` に関連リンクと補足を追加

## 確認
- `yq eval . patches/controlplane.yaml`
- controlplane への `apply-config` が通ることを手元で確認済み
- `scripts/ops/**` を実行する追加検証は repo ルールに合わせて未実施
