### PR TITLE
[codex] Route cluster traffic away from tailscale

### DIFF
--- a/docs/networking-stack.md
+++ b/docs/networking-stack.md
@@ -44,6 +44,7 @@
 ## 実装上の前提
 
 - `KubeSpan` は node-to-node 通信用の WireGuard として使う
+- `KubeSpan` は通常の node-to-node 経路の唯一の overlay とし、`tailscale0` は管理アクセス専用に寄せる
 - Pod ネットワークと `NetworkPolicy` は `Calico` に任せる
 - Service 転送は `Calico eBPF` に任せる
 - `kube-proxy` は導入しない
@@ -54,50 +55,16 @@ TalOS 側では、`cluster.network.cni.name` を `none` にする前提で構成
 `KubeSpan` では `advertiseKubernetesNetworks` を有効化しません。
 `Calico` は Pod IP を独自に扱うため、この設定を併用しない前提で設計します。
 
-## 採用しなかった案
+`KubeSpan` の endpoint には Tailscale の address range を載せません。
+TalOS の `filters.endpoints` で `100.64.0.0/10` と `fd7a:115c:a1e0::/48` を除外し、通常の node 間通信を `tailscale0` に乗せない前提で運用します。
 
-### `KubeSpan + TalOS-managed Flannel`
-
-採用しません。
-
-理由:
-
-- `Flannel` 単体では `NetworkPolicy` を実装しない
-- 今回の要件では不足する
-
-### `KubeSpan + Canal`
-
-採用しません。
-
-理由:
-
-- `Canal` は堅実だが、今回は `Calico eBPF` の機能を優先する
-- `Flannel` dataplane を残す必然がなくなった
-
-### `KubeSpan + Calico NFTables`
-
-今回は第一候補にしません。
-
-理由:
-
-- より保守的で切り分けしやすいが、今回は `eBPF` 構成を優先する
-
-補足:
-
-- `Calico NFTables` は、`eBPF` 構成が期待どおりに安定しない場合の第一ロールバック先とする
-
-### `Kilo + WireGuard`
-
-採用しません。
-
-理由:
-
-- TalOS では `KubeSpan` が同系統の用途をより直接的に満たす
-- このクラスタでまず必要なのは multi-cluster 機能ではない
+`allowDownPeerBypass` は無効のまま運用します。
+`KubeSpan` が不通でも平文経路へ自動で逃がさないことで、node 間暗号化の前提を崩さないようにします。
 
 ## 運用メモ
 
 - `KubeSpan` 用に UDP `51820` を通す
+- `Tailscale` は TalOS API や緊急時の管理アクセスにだけ使い、通常の node-to-node 通信には使わない
 - TalOS ingress firewall patch 自体はこの repo では管理せず、private repo 側で別管理する
 - `Calico eBPF` は `kube-proxy` なし前提なので、bootstrap 手順と manifest 適用順を固定する
 
@@ -107,15 +74,12 @@ TalOS 側では、`cluster.network.cni.name` を `none` にする前提で構成
 - 問題が起きたとき、切り分けは `NFTables` より難しくなる
 - `KubeSpan` と `Calico` の責務分担を崩す設定を入れると、経路問題の調査が難しくなる
 
-## 見直し条件
+## 現在の懸念
 
-次のいずれかが発生した場合は、この判断を見直します。
+現時点で、`KubeSpan` と `Calico` の組み合わせで経路または MTU 問題が再現していると見ています。
+そのため、通常の node-to-node 通信は `KubeSpan` に寄せたまま、`tailscale0` を通常経路の候補から外して切り分ける前提で進めます。
 
-- `Calico eBPF` で安定運用できない
-- `kube-proxy` なし構成の運用負荷が高い
-- `KubeSpan` と `Calico` の組み合わせで経路または MTU 問題が継続する
-- `Calico NFTables` へ下げる方が合理的だと判断した
-- TalOS 側の標準的な推奨構成が大きく変わった
+この切り分けでも問題が残る場合は、underlay MTU の再確認と `kubespan.mtu` の調整を次の候補にします。
 
 ## 参考
 

--- a/docs/tailscale.md
+++ b/docs/tailscale.md
@@ -93,12 +93,24 @@ talosctl get addresses \
   --talosconfig "$TALOSCONFIG" \
   --endpoints "$CONTROL_PLANE_ENDPOINT" \
   --nodes "$CONTROL_PLANE_ENDPOINT"
+
+talosctl get kubespanpeerspecs \
+  --talosconfig "$TALOSCONFIG" \
+  --endpoints "$CONTROL_PLANE_ENDPOINT" \
+  --nodes "$CONTROL_PLANE_ENDPOINT"
+
+talosctl get kubespanendpoints \
+  --talosconfig "$TALOSCONFIG" \
+  --endpoints "$CONTROL_PLANE_ENDPOINT" \
+  --nodes "$CONTROL_PLANE_ENDPOINT"
 ```
 
 見たいもの:
 
 - `ExtensionServiceConfig` に `tailscale` がある
 - `tailscale0` interface がある
+- `kubespanpeerspecs` の peer が `up` になっている
+- `kubespanendpoints` に Tailscale の `100.x` や `fd7a:115c:a1e0::/48` が通常経路として出てこない
 
 Tailscale admin 側:
 
@@ -111,5 +123,14 @@ Tailscale admin 側:
 ## 補足
 
 - `KubeSpan` は node 間メッシュのまま維持します。Tailscale は管理アクセスの追加経路です。
+- `patches/common.yaml` では `KubeSpan` の `filters.endpoints` で Tailscale の address range を除外し、通常の node-to-node 通信を `tailscale0` に寄せません。
+- `allowDownPeerBypass=false` を明示し、`KubeSpan` が張れていない peer へ平文経路で逃がしません。
 - `TS_ACCEPT_DNS=false` を既定にしています。TalOS 側で `hostDNS` を使っているため、最初から tailnet DNS を被せません。
 - `TAILSCALE_*_TAGS` は `tailscale up --advertise-tags=...` へ変換されます。
+- `KubeSpan` の MTU は TalOS の既定値 `1420` を前提にしています。underlay MTU が `1500` 未満と分かった場合だけ、別作業で `kubespan.mtu` を調整します。
+
+## 切り戻し
+
+- `tailscale0` を node 間通信の候補へ戻したい場合は、`patches/common.yaml` から `filters.endpoints` の Tailscale 除外を外して TalOS config を再生成し、各 node へ再適用します。
+- 変更後に node 間疎通が悪化した場合は、変更前の machine config を再適用して戻します。
+- Tailscale extension 自体は削除していないため、切り戻し時も管理アクセス経路はそのまま使えます。

--- a/manifests/bootstrap/calico/30-installation.yaml
+++ b/manifests/bootstrap/calico/30-installation.yaml
@@ -3,16 +3,18 @@ kind: Installation
 metadata:
   name: default
 spec:
-  variant: Calico
+  variant: Calico # OSS 版の Calico を使う
   calicoNetwork:
-    linuxDataplane: BPF
-    kubeProxyManagement: Enabled
-    bgp: Disabled
+    linuxDataplane: BPF # Service 転送も含めて Calico eBPF dataplane を使う
+    kubeProxyManagement: Enabled # kube-proxy を置かずに Calico が Service 処理を担う
+    bgp: Disabled # node 間経路交換は BGP ではなく overlay に寄せる
+    nodeAddressAutodetectionV4:
+      skipInterface: ^tailscale0$ # tailscale0 を node IP 自動検出の候補から外し、underlay 側の address を使わせる
     ipPools:
-      - name: default-ipv4-ippool
-        blockSize: 26
-        cidr: 10.244.0.0/16
-        encapsulation: VXLAN
-        natOutgoing: Enabled
-        nodeSelector: all()
-  kubeletVolumePluginPath: None
+      - name: default-ipv4-ippool # cluster 全体で使う既定の Pod IPv4 pool
+        blockSize: 26 # node ごとに /26 単位で Pod IP を割り当てる
+        cidr: 10.244.0.0/16 # Pod network 全体の CIDR
+        encapsulation: VXLAN # Pod 通信の overlay は VXLAN を維持する
+        natOutgoing: Enabled # cluster 外向き通信は node 側 IP へ NAT する
+        nodeSelector: all() # 全 node をこの IP pool の対象にする
+  kubeletVolumePluginPath: None # TalOS では flex volume plugin path を使わない

--- a/manifests/bootstrap/calico/32-felixconfiguration.yaml
+++ b/manifests/bootstrap/calico/32-felixconfiguration.yaml
@@ -3,4 +3,5 @@ kind: FelixConfiguration
 metadata:
   name: default
 spec:
-  cgroupV2Path: /sys/fs/cgroup
+  cgroupV2Path: /sys/fs/cgroup # TalOS の cgroup v2 mount を Felix に明示する
+  vxlanMTU: 1370 # kubespan MTU 1420 の上で VXLAN 分を見込んだ Pod network MTU

--- a/patches/common.yaml
+++ b/patches/common.yaml
@@ -2,7 +2,14 @@ machine:
   network:
     kubespan:
       enabled: true
+      allowDownPeerBypass: false
       advertiseKubernetesNetworks: false
+      filters:
+        endpoints:
+          - 0.0.0.0/0
+          - '!100.64.0.0/10' # tailscale ranges
+          - ::/0
+          - '!fd7a:115c:a1e0::/48'
   install:
     disk: /dev/sda
     image: factory.talos.dev/installer/708747e350d604ae9e57227d8dcf274091453ddb1097b765d4ea8884f1992c1f:v1.12.6


### PR DESCRIPTION
## 概要

Tailscale を管理アクセス用に寄せつつ、通常の node-to-node 通信で `tailscale0` を掴まないように Talos と Calico の設定を調整します。

## 変更内容

- Talos の `KubeSpan` に `allowDownPeerBypass: false` と endpoint filter を追加し、Tailscale のアドレス帯を通常経路の候補から除外
- Calico の `Installation` で `nodeAddressAutodetectionV4.skipInterface: ^tailscale0$` を設定し、node IP 自動検出から `tailscale0` を除外
- Calico の `FelixConfiguration` で `vxlanMTU: 1370` を明示
- ネットワーク方針、確認手順、切り戻し手順をドキュメントへ追記

## 背景

- `KubeSpan` と `Calico` の組み合わせで経路または MTU 問題が再現していた
- Calico が `firstFound` の既定動作で `tailscale0` の `100.x` を node IP として掴んでいた
- そのため、通常のクラスタ通信を Tailscale に寄せないように明示設定が必要だった

## 確認

- `Installation` が `Ready=True`, `Progressing=False`, `Degraded=False` へ収束
- `Installation.status.mtu` が `1370` へ更新
- `projectcalico.org/IPv4Address` が `100.x` ではなく underlay 側アドレスへ切り替わることを確認
- `talosctl get kubespanpeerstatuses` で全 peer が `up` であり、`RX/TX` カウンタが増加していることを確認

## 影響

- 管理アクセス用の Tailscale は維持
- 通常の node-to-node 通信は KubeSpan を優先する構成へ寄せる
