### PR TITLE
[codex] Avoid Tailscale node IP selection

### DIFF
--- a/docs/networking-stack.md
+++ b/docs/networking-stack.md
@@ -58,6 +58,10 @@ TalOS 側では、`cluster.network.cni.name` を `none` にする前提で構成
 `KubeSpan` の endpoint には Tailscale の address range を載せません。
 TalOS の `filters.endpoints` で `100.64.0.0/10` と `fd7a:115c:a1e0::/48` を除外し、通常の node 間通信を `tailscale0` に乗せない前提で運用します。
 
+Kubernetes の NodeInternalIP も Tailscale の address range を候補から外します。
+TalOS の `machine.kubelet.nodeIP.validSubnets` では `100.64.0.0/10` を除外し、public repository には実 node subnet を列挙しません。
+Calico の node address autodetection は `skipInterface: ^tailscale0$` を使い、Tailscale ではなく underlay 側の address を選ばせます。
+
 `allowDownPeerBypass` は無効のまま運用します。
 `KubeSpan` が不通でも平文経路へ自動で逃がさないことで、node 間暗号化の前提を崩さないようにします。
 

--- a/patches/common.yaml
+++ b/patches/common.yaml
@@ -10,6 +10,11 @@ machine:
           - '!100.64.0.0/10' # tailscale ranges
           - ::/0
           - '!fd7a:115c:a1e0::/48'
+  kubelet:
+    nodeIP:
+      validSubnets:
+        - 0.0.0.0/0
+        - '!100.64.0.0/10' # do not publish tailscale0 as NodeInternalIP
   install:
     disk: /dev/sda
     image: factory.talos.dev/installer/708747e350d604ae9e57227d8dcf274091453ddb1097b765d4ea8884f1992c1f:v1.12.6


### PR DESCRIPTION
  ## 今回の変更箇所

  この PR では、Calico の `nodeAddressAutodetectionV4.skipInterface: ^tailscale0$` は変更していません。以前の調査で underlay 側 address を選ばせるために有効だった設定として、そのま
  ま維持しています。

  変更したのは Talos kubelet の NodeInternalIP 選択です。

  - `patches/common.yaml`
    - `machine.kubelet.nodeIP.validSubnets` を追加しました。
    - `0.0.0.0/0` は許可しつつ、`100.64.0.0/10` を除外しています。
    - これにより kubelet が `tailscale0` の Tailscale IP を Kubernetes NodeInternalIP として publish しないようにします。

  ## 何かあった時の戻し方

  `patches/common.yaml` から以下のブロックを削除して Talos config を再生成・再適用します。

  ```yaml
    kubelet:
      nodeIP:
        validSubnets:
          - 0.0.0.0/0
          - '!100.64.0.0/10'

  Calico manifest は今回変更していないため、Calico 側を戻す作業は不要です。

  ## デプロイ後の確認方法

  kubectl get nodes -o wide

  期待値:

  - mishship-con-w01 の INTERNAL-IP が 100.81.140.12 ではなくなる。
  - Tailscale range 100.64.0.0/10 の IP が NodeInternalIP として表示されない。

  kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{" internal="}{range .status.addresses[?(@.type=="InternalIP")]}{.address}{end}{" calico="}
  {.metadata.annotations.projectcalico\.org/IPv4Address}{"\n"}{end}'

  期待値:

  - mishship-con-w01 internal= が Tailscale IP ではない。
  - calico= は引き続き underlay 側 address を指す。

  talosctl -n <node-ip> get kubespanpeerstatus

  期待値:

  - peer が state: up。
  - lastHandshakeTime が更新されている。
  - lastUsedEndpoint が Tailscale ではなく underlay 側 endpoint を使っている。

  kubectl -n monitoring get pod grafana-k8s-monitoring-alloy-operator-8df47458c-q4bd8 -o wide
  kubectl -n monitoring logs grafana-k8s-monitoring-alloy-operator-8df47458c-q4bd8 --tail=200

  期待値:

  - restart count が増え続けない。
  - leader election lost、Failed to update lock、context deadline exceeded が再発しない。
